### PR TITLE
Add 'extra=ignore' argument in `SettingsConfigDict` object.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/src/config.py
+++ b/src/config.py
@@ -31,7 +31,8 @@ class Config(BaseSettings):
 
     model_config = SettingsConfigDict(
         yaml_file=yaml_file,
-        yaml_file_encoding='utf-8'
+        yaml_file_encoding='utf-8',
+        extra='ignore'
     )
 
     app: AppConfig


### PR DESCRIPTION
For additional configuration in the yaml file, we add 'extra=ignore' argument in `SettingsConfigDict` init method.